### PR TITLE
feature: Handle popping empty lists

### DIFF
--- a/spec/bojack/server_spec.cr
+++ b/spec/bojack/server_spec.cr
@@ -116,6 +116,25 @@ describe BoJack::Server do
           buffer.should eq("error: 'bar' is not a valid key\n")
         end
       end
+
+      context "with no more items to pop" do
+        it "returns empty response" do
+          socket.puts("set list foo,bar")
+          socket.gets
+
+          socket.puts("pop list")
+          socket.gets
+          socket.puts("pop list")
+          socket.gets
+          socket.puts("pop list")
+
+          buffer = socket.gets
+          
+          buffer.should eq("\n")
+          socket.puts("delete list")
+          socket.gets
+        end
+      end
     end
 
     describe "delete" do

--- a/src/bojack/commands/pop.cr
+++ b/src/bojack/commands/pop.cr
@@ -6,7 +6,10 @@ module Bojack
       self.keyword = "pop"
 
       def execute(memory, key, value)
-        memory.read(key).pop
+        list = memory.read(key)
+        
+        return nil if list.empty?
+        list.pop
       rescue
         "error: '#{key}' is not a valid key"
       end


### PR DESCRIPTION
When a list is nil but still exists, it is better to tell the users that
it is nill instead of raising a 'key error' message.
