### PR TITLE
refactor: Set tcp_nodelay to true to disable Nagle's algorithm

### DIFF
--- a/src/bojack/client.cr
+++ b/src/bojack/client.cr
@@ -7,6 +7,7 @@ module BoJack
 
     def initialize(@hostname = "127.0.0.1", @port = 5000)
       @socket = TCPSocket.new(@hostname, @port)
+      @socket.tcp_nodelay = true
     end
 
     def set(key, value)

--- a/src/bojack/server.cr
+++ b/src/bojack/server.cr
@@ -12,6 +12,7 @@ module BoJack
 
     def start
       server = TCPServer.new(@hostname, @port)
+      server.tcp_nodelay = true
       server.recv_buffer_size = 4096
       memory = BoJack::Memory(String, Array(String)).new
 


### PR DESCRIPTION
As discussed in #17 this disabled Nagle's algorithm improving the performance when using same TCP connection. [This](https://gist.github.com/hugoabonizio/79cb90645a50dbf6b4d8dd7aed920c84) benchmark can be used to see the difference.
