### PR TITLE
Max CPU usage after client closes

### DIFF
--- a/src/bojack/server.cr
+++ b/src/bojack/server.cr
@@ -32,9 +32,9 @@ module BoJack
 
           spawn do
             loop do
-              if message = socket.gets
-                @channel.send(BoJack::Request.new(message, socket, @memory))
-              end
+              message = socket.gets
+              break unless message
+              @channel.send(BoJack::Request.new(message, socket, @memory))
             end
           end
         end


### PR DESCRIPTION
After sending a request on a client the BoJack server keeps reading empy messages on infinite loop.

My client.rb:

``` ruby
client = BoJack::Client.new

Benchmark.bm do |x|
  x.report "set" do
    100.times do |i|
      client.set "bo#{i}", "jack"
    end
  end
end
```

Similar to #4.
