### PR TITLE
Format logger datetime as UTC

### DIFF
--- a/src/bojack/logger.cr
+++ b/src/bojack/logger.cr
@@ -4,7 +4,7 @@ module BoJack
   class Logger < ::Logger
     @@instance : BoJack::Logger = BoJack::Logger.new(STDOUT)
 
-    def self.build(io : (IO | String) = STDOUT, level : Int32 = 1, hostname : String = "127.0.0.1",  port : Int32 = 5000)
+    def self.build(io : (IO | String) = STDOUT, level : Int32 = 1, hostname : String = "127.0.0.1", port : Int32 = 5000)
       if io.is_a?(String)
         basename = File.basename(io, ".log")
         path = File.dirname(io)
@@ -16,6 +16,7 @@ module BoJack
       @@instance = BoJack::Logger.new(io)
       @@instance.level = BoJack::Logger::Severity.new(level)
       @@instance.formatter = BoJack::Logger::Formatter.new do |severity, datetime, progname, message, io|
+        datetime = datetime.to_utc.to_s("%Y-%m-%d %H:%M:%S.%L")
         io << "[bojack][#{hostname}:#{port}][#{datetime}][#{severity}] #{message}"
       end
     end


### PR DESCRIPTION
Fixes #60.

Before:
`[bojack][127.0.0.1:5000][2018-01-25 09:10:35 -02:00][INFO] BoJack is running at 127.0.0.1:5000`

After:
`[bojack][127.0.0.1:5000][2018-01-25 11:10:35.020][INFO] BoJack is running at 127.0.0.1:5000`

For reference: [Time::Format](https://crystal-lang.org/api/0.24.1/Time/Format.html).